### PR TITLE
support for scanning packages without recursion

### DIFF
--- a/venusian/__init__.py
+++ b/venusian/__init__.py
@@ -11,7 +11,7 @@ class Scanner(object):
     def __init__(self, **kw):
         self.__dict__.update(kw)
 
-    def scan(self, package, categories=None):
+    def scan(self, package, categories=None, recursive=True):
         """ Scan a Python package and any of its subpackages.  All
         top-level objects will be considered; those marked with
         venusian callback attributes related to ``category`` will be
@@ -66,7 +66,7 @@ class Scanner(object):
         for name, ob in inspect.getmembers(package):
             invoke(name, ob)
 
-        if hasattr(package, '__path__'): # package, not module
+        if recursive and hasattr(package, '__path__'): # package, not module
             results = walk_packages(package.__path__, package.__name__+'.')
 
             for importer, modname, ispkg in results:

--- a/venusian/tests/fixtures/recursion/__init__.py
+++ b/venusian/tests/fixtures/recursion/__init__.py
@@ -1,0 +1,5 @@
+from venusian.tests.fixtures import decorator
+
+@decorator(function=True)
+def package_function(request): # pragma: no cover
+    return request

--- a/venusian/tests/fixtures/recursion/module.py
+++ b/venusian/tests/fixtures/recursion/module.py
@@ -1,0 +1,18 @@
+from venusian.tests.fixtures import decorator
+
+@decorator(function=True)
+def function(request): # pragma: no cover
+    return request
+
+class Class(object):
+    @decorator(method=True)
+    def method(self, request): # pragma: no cover
+        return request
+    
+class Instance(object):
+    def __call__(self, request): # pragma: no cover
+        return request
+
+inst = Instance()
+inst = decorator(instance=True)(inst)
+

--- a/venusian/tests/fixtures/recursion/module2.py
+++ b/venusian/tests/fixtures/recursion/module2.py
@@ -1,0 +1,18 @@
+from venusian.tests.fixtures import decorator
+
+@decorator(function=True)
+def function(request): # pragma: no cover
+    return request
+
+class Class(object):
+    @decorator(method=True)
+    def method(self, request): # pragma: no cover
+        return request
+    
+class Instance(object):
+    def __call__(self, request): # pragma: no cover
+        return request
+
+inst = Instance()
+inst = decorator(instance=True)(inst)
+

--- a/venusian/tests/test_venusian.py
+++ b/venusian/tests/test_venusian.py
@@ -54,6 +54,17 @@ class TestScanner(unittest.TestCase):
         self.assertEqual(test.registrations[5]['ob'], inst2)
         self.assertEqual(test.registrations[5]['instance'], True)
 
+    def test_package_without_recursion(self):
+        from venusian.tests.fixtures import recursion
+        test = Test()
+        scanner = self._makeOne(test=test)
+        scanner.scan(recursion, recursive=False)
+        self.assertEqual(len(test.registrations), 1)
+
+        self.assertEqual(test.registrations[0]['name'], 'package_function')
+        self.assertEqual(test.registrations[0]['ob'], recursion.package_function)
+        self.assertEqual(test.registrations[0]['function'], True)
+
     def test_package_with_orphaned_pyc_file(self):
         # There is a module2.pyc file in the "pycfixtures" package; it
         # has no corresponding .py source file.  Such orphaned .pyc


### PR DESCRIPTION
I've needed this on more than one occasion, typically because I want to scan the submodules with a different set of scanner parameters (attributes) than when scanning the top-level package.
