### PR TITLE
 Pass the ignore argument to the recursive call

### DIFF
--- a/venusian/__init__.py
+++ b/venusian/__init__.py
@@ -353,7 +353,7 @@ def walk_packages(path=None, prefix='', onerror=None, ignore=None):
                 # don't traverse path items we've seen before
                 path = [p for p in path if not seen(p)]
 
-                for item in walk_packages(path, name+'.', onerror):
+                for item in walk_packages(path, name+'.', onerror, ignore):
                     yield item
         else:
             yield importer, name, ispkg


### PR DESCRIPTION
Otherwise we can only ignore top level packages

This is my use case in a Pyramid application:

config.scan(ignore=[re.compile('._tests._').search, '.testing'])

And without this patch, it is not ignoring the second level packages, which include tests.
