### PR TITLE
Sort modules by name during scan for repeatability.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -104,3 +104,4 @@ Contributors
 - Chris McDonough, 2011/02/16
 - Chris Withers, 2011/03/14
 - Joel Bohman, 2011/07/28
+- Laurence Rowe, 2013/03/19

--- a/venusian/__init__.py
+++ b/venusian/__init__.py
@@ -331,7 +331,9 @@ def walk_packages(path=None, prefix='', onerror=None, ignore=None):
         m[p] = True
 
     # iter_modules is nonrecursive
-    for importer, name, ispkg in iter_modules(path, prefix):
+    # sorted by module name for repeatability
+    for importer, name, ispkg in sorted(iter_modules(path, prefix),
+                                        key=lambda item: item[1]):
 
         if ignore is not None and ignore(name):
             # if name is a package, ignoring here will cause


### PR DESCRIPTION
This should ensure directives are executed in a consistent order across runs.