### PR TITLE
first pass at a fix for handling bad magic data

### DIFF
--- a/venusian/__init__.py
+++ b/venusian/__init__.py
@@ -161,7 +161,12 @@ class Scanner(object):
                 category_keys.sort()
             for category in category_keys:
                 callbacks = attached_categories.get(category, [])
-                for callback, cb_mod_name, liftid, scope in callbacks:
+                for maybe_cb in callbacks:
+                    # ignore bad data from objects messing with magic methods
+                    if not hasattr(maybe_cb, '__len__') or len(maybe_cb) != 4:
+                        continue
+                    # otherwise unpack the data
+                    callback, cb_mod_name, liftid, scope = maybe_cb
                     if cb_mod_name != mod_name:
                         # avoid processing objects that were imported into this
                         # module but were not actually defined there


### PR DESCRIPTION
Certain types of objects (like mock.call when imported at the module level) override magic methods and end up supplying the venusian `Scanner` with unexpected data. Here's a small, reproducible example:

```python
import sys
from mock import call
from venusian import Scanner

if __name__ == '__main__':
    this_module = sys.modules['__main__']
    Scanner().scan(this_module)
```
If you run this you should see an error similar to:

```console
        File "/path/to/venusian/venusian/__init__.py", line 164, in invoke
          for callback, cb_mod_name, liftid, scope in callbacks:
      ValueError: too many values to unpack
```

This is problematic because the stack trace won't necessarily include the module or import line that is causing the error.

A more robust fix would probably involve not adding bad data to the callback list in the first place, but since I have limited knowledge of venusian internals I'm supplying a patch to ignore any data that can't be unpacked correctly.

Please let me know what code changes would be required to accept this patch, and also I'm hoping you can point me to a test case I can use as a basis for writing a new unit test to cover this case. I'm not really sure where to get started with how to write an idiomatic venusian test.
