### PR TITLE
Check for TypeError and ValueError when scanning

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,9 @@
   Venusian decorators should have never been inherited implicitly.  See
   https://github.com/Pylons/venusian/issues/11#issuecomment-4977352
 
+- Make scanning more resilient of metaclasses that return proxies for any
+  attribute access.
+
 1.0a8 (2013-04-15)
 ------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -104,3 +104,4 @@ Contributors
 - Chris McDonough, 2011/02/16
 - Chris Withers, 2011/03/14
 - Joel Bohman, 2011/07/28
+- Olaf Conradi, 2013/09/16

--- a/venusian/__init__.py
+++ b/venusian/__init__.py
@@ -158,15 +158,28 @@ class Scanner(object):
                 return
             if category_keys is None:
                 category_keys = list(attached_categories.keys())
-                category_keys.sort()
+                try:
+                    # When metaclasses return proxies for any attribute access
+                    # the list may contain keys of different types which might
+                    # not be sortable.  In that case we can just return,
+                    # because we're not dealing with a proper venusian
+                    # callback.
+                    category_keys.sort()
+                except TypeError:
+                    return
             for category in category_keys:
                 callbacks = attached_categories.get(category, [])
-                for callback, cb_mod_name, liftid, scope in callbacks:
-                    if cb_mod_name != mod_name:
-                        # avoid processing objects that were imported into this
-                        # module but were not actually defined there
-                        continue
-                    callback(self, name, ob)
+                try:
+                    # Metaclasses might trick us by reaching this far and then
+                    # fail with too little values to unpack.
+                    for callback, cb_mod_name, liftid, scope in callbacks:
+                        if cb_mod_name != mod_name:
+                            # avoid processing objects that were imported into
+                            # this module but were not actually defined there
+                            continue
+                        callback(self, name, ob)
+                except ValueError:
+                    continue
 
         for name, ob in getmembers(package):
             # whether it's a module or a package, we need to scan its

--- a/venusian/tests/fixtures/import_and_scan/mock.py
+++ b/venusian/tests/fixtures/import_and_scan/mock.py
@@ -1,0 +1,27 @@
+class _Call(tuple):  # pragma: no cover
+    def __new__(cls, value=(), name=None):
+        name = ''
+        args = ()
+        kwargs = {}
+        _len = len(value)
+        if _len == 3:
+            name, args, kwargs = value
+        return tuple.__new__(cls, (name, args, kwargs))
+
+    def __init__(self, value=(), name=None):
+        self.name = name
+
+    def __call__(self, *args, **kwargs):
+        if self.name is None:
+            return _Call(('', args, kwargs), name='()')
+        else:
+            return _Call((self.name, args, kwargs), name=self.name + '()')
+
+    def __getattr__(self, attr):
+        if self.name is None:
+            return _Call(name=attr)
+        else:
+            return _Call(name='%s.%s' % (self.name, attr))
+
+
+call = _Call()


### PR DESCRIPTION
Python 3 throws an exception when sorting a list of unorderable types. In
Python 2 that we might get past that point but when extracting values from
a callback tuple it might not have enough values.