### PR TITLE
Make test decorator work outside tests

### DIFF
--- a/venusian/tests/fixtures/__init__.py
+++ b/venusian/tests/fixtures/__init__.py
@@ -2,13 +2,17 @@ import venusian
 
 class decorator(object):
     category = None
+    call_count = 0
+
     def __init__(self, **kw):
         self.__dict__.update(kw)
 
     def __call__(self, wrapped):
         view_config = self.__dict__.copy()
         def callback(context, name, ob):
-            context.test(ob=ob, name=name, **view_config)
+            if hasattr(context, 'test'):
+                context.test(ob=ob, name=name, **view_config)
+            self.__class__.call_count += 1
         info = venusian.attach(wrapped, callback, category=self.category)
         if info.scope == 'class':
             # we're in the midst of a class statement


### PR DESCRIPTION
Because some folks might be like me and might assume that they can call `scan` on the modules in the `tests/fixtures` directory and might be puzzled when they do this and get:

    AttributeError: 'Scanner' object has no attribute 'test'

This makes the decorator not barf when used outside the test suite.

I also added a `call_count` static attribute that might be useful in the future for making assertions about how many times the `callback` is called.

Fixes GH-46