### PR TITLE
tox.ini: Add a "cover3" target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,20 @@ deps =
     nosexcover
     nose-exclude<0.2
 
+[testenv:cover3]
+# we separate coverage into its own testenv because a) "last run wins" wrt
+# cobertura jenkins reporting and b) pypy and jython can't handle any
+# combination of versions of coverage and nosexcover that i can find.
+basepython =
+    python3.4
+commands =
+    nosetests --with-xunit --with-xcoverage
+deps =
+    nose
+    coverage
+    nosexcover
+    nose-exclude<0.2
+
 # nose-exclude 0.2.X breaks both pypy and python3; see
 # https://bitbucket.org/kgrandis/nose-exclude/issue/10/test-failures-with-python-3
 


### PR DESCRIPTION
so we can look at test coverage for Python 3 separately, as there are some definite gaps there, as evidenced by the confusion around:

- https://github.com/Pylons/venusian/pull/43
- https://github.com/Pylons/venusian/issues/44
- https://github.com/Pylons/venusian/pull/45

It currently fails because the coverage is not 100%.

    [marca@marca-mac2 venusian]$ tox -e cover3
    ...
    -----------------------------------------------------------------------------------
    TOTAL                                                  1017     14    99%
    nose.plugins.cover: ERROR: TOTAL Coverage did not reach minimum required: 100%
    ERROR: InvocationError: '/Users/marca/dev/git-repos/venusian/.tox/cover3/bin/nosetests --with-xunit --with-xcoverage'
    _________________________________________________________________________________________________________________________________________________________
    summary
    __________________________________________________________________________________________________________________________________________________________
    ERROR:   cover3: commands failed

Cc: @tseaver, @wichert