### PR TITLE
Allow nose-exclude 0.4.0 to be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except:
 
 tests_extras = [
     'nose',
-    'nose-exclude<0.2', #  0.2.X has issues under py3
+    'nose-exclude != 0.2.0, != 0.3.0', #  0.2 ~ 0.3 has issues under py3
     'coverage'
     ]
 docs_extras = ['Sphinx', 'repoze.sphinx.autointerface']


### PR DESCRIPTION
nose-exclude fixed the py3 issues since 0.4.0, so let's exclude only the broken versions.