### PR TITLE
Drop support for Python 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 env:
   - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=pypy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
-Next release
-------------
+1.1 (unreleased)
+----------------
+
+- Deprecate support for Python 2.6:  it will be removed in the 1.2
+  release.
+
+- Drop support for Python 3.2:  it is no longer supported by current
+  packaging / CI tools.
 
 - Support loaders that require the module name as argument to their
   ``get_filename()`` method. This fixes problems with zipped packages

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ tests_extras = [
 docs_extras = ['Sphinx', 'repoze.sphinx.autointerface']
 
 setup(name='venusian',
-      version='1.0',
+      version='1.1-dev0',
       description='A library for deferring decorator actions',
       long_description=README + '\n\n' +  CHANGES,
       classifiers=[
@@ -46,7 +46,6 @@ setup(name='venusian',
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: Implementation :: CPython",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py32,py33,py34,pypy,pypy3,docs,{py2,py3}-cover,coverage
+    py26,py27,py33,py34,pypy,pypy3,docs,{py2,py3}-cover,coverage
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.2 is no longer supported by current packaging / CI tools.

Deprecate support for Python 2.6:  it will be removed in the next release.