### PR TITLE
Bump to 3.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+3.0.0 (2019-10-04)
+------------------
+
+- This release matches 2.0.0 other than in the version number. This fixes an
+  issue with Requires-Python metadata not being uploaded correctly to PyPi.
+
+  This version is only compatible with Python 3.5+
+
 2.0.0 (2019-10-04)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = venusian
-version = 2.0.0
+version = 3.0.0
 description = A library for deferring decorator actions
 long_description = file: README.rst, CHANGES.rst
 long_description_content_type = text/x-rst
@@ -19,12 +19,12 @@ classifiers =
 url = https://pylonsproject.org/
 author = Chris McDonough, Agendaless Consulting
 author_email = pylons-devel@googlegroups.com
-python_requires = >=3.5
 
 [options]
 package_dir=
     =src
 packages=find:
+python_requires = >=3.5
 
 [options.packages.find]
 where=src
@@ -39,7 +39,7 @@ docs =
     repoze.sphinx.autointerface
 
 [bdist_wheel]
-universal=1
+universal=0
 
 [tool:pytest]
 ignore=tests/fixtures/


### PR DESCRIPTION
Looks like the released 3.0.0 version has not reflected to the master. Copied code from release assets.