### PR TITLE
Add license classifier to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
+    License :: Repoze Public License
 url = https://pylonsproject.org/
 author = Chris McDonough, Agendaless Consulting
 author_email = pylons-devel@googlegroups.com


### PR DESCRIPTION
To have unified license specification like in https://github.com/Pylons/pyramid/blob/master/setup.py#L85

Note that will allow (imperfect) tools like https://github.com/pivotal/LicenseFinder to automatically recognize the license, which is currently (v6.6.1) recognized as `unknown`.