### PR TITLE
Fixing the doc while reading it.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -173,7 +173,7 @@ demonstrated below.
 
    def jsonify(wrapped):
        def callback(scanner, name, ob):
-           print 'jsonified'
+           print('jsonified')
        venusian.attach(wrapped, callback)
        return wrapped
 
@@ -200,7 +200,7 @@ doesn't actually change its behavior.
    :linenos:
 
    >>> from theapp import logged_in
-   >>> logged_in()
+   >>> logged_in(None)
    {'result':'Logged in'}
    >>>
 


### PR DESCRIPTION
All in the title: I was reading the doc and found them:

- A Python 2 era print
- The call of `logged_in` needs the `request` argument, giving `None` as in the previous example.