### PR TITLE
chore: tweak configs to match pyramid

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,9 +99,11 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4 and 3.5, and for PyPy. Check
-   https://travis-ci.org/Pylons/venusian/pull_requests
-   and make sure that the tests pass for all supported Python versions.
+3. The pull request should work for all supported versions of Python
+   (see the `classifiers` section in
+   https://github.com/Pylons/venusian/blob/main/setup.cfg).  Verify
+   that the "All checks have passed" flag is green on the "Conversation"
+   page of the PR before merging.
 
 Tips
 ----

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,111 @@
+.. highlight:: shell
+
+============
+Contributing
+============
+
+Contributions are welcome, and they are greatly appreciated! Every
+little bit helps, and credit will always be given.
+
+You can contribute in many ways:
+
+Types of Contributions
+----------------------
+
+Report Bugs
+~~~~~~~~~~~
+
+Report bugs at https://github.com/Pylons/venusian/issues.
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+Fix Bugs
+~~~~~~~~
+
+Look through the GitHub issues for bugs. Anything tagged with "bug"
+is open to whoever wants to implement it.
+
+Implement Features
+~~~~~~~~~~~~~~~~~~
+
+Look through the GitHub issues for features. Anything tagged with "feature"
+is open to whoever wants to implement it.
+
+Write Documentation
+~~~~~~~~~~~~~~~~~~~
+
+venusian could always use more documentation, whether as part of the
+official venusian docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+Submit Feedback
+~~~~~~~~~~~~~~~
+
+The best way to send feedback is to file an issue at
+https://github.com/Pylons/venusian/issues.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+Get Started!
+------------
+
+Ready to contribute? Here's how to set up `venusian` for local development.
+
+1. Fork the `venusian` repo on GitHub.
+2. Clone your fork locally::
+
+    $ git clone git@github.com:your_name_here/venusian.git
+
+3. Install your local copy into a virtualenv::
+
+    $ python3 -m venv env
+    $ env/bin/pip install -e .[docs,testing]
+    $ env/bin/pip install tox
+
+4. Create a branch for local development::
+
+    $ git checkout -b name-of-your-bugfix-or-feature
+
+   Now you can make your changes locally.
+
+5. When you're done making changes, check that your changes pass flake8 and
+   the tests, including testing other Python versions with tox::
+
+    $ env/bin/tox
+
+6. Commit your changes and push your branch to GitHub::
+
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+
+7. Submit a pull request through the GitHub website.
+
+Pull Request Guidelines
+-----------------------
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in README.rst.
+3. The pull request should work for Python 2.7, 3.4 and 3.5, and for PyPy. Check
+   https://travis-ci.org/Pylons/venusian/pull_requests
+   and make sure that the tests pass for all supported Python versions.
+
+Tips
+----
+
+To run a subset of tests::
+
+$ env/bin/py.test tests.test_venusian

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,18 +1,18 @@
 graft src/venusian
-graft tests
 graft docs
-graft .github
+prune docs/_build
+graft tests
 
 include README.rst
 include CHANGES.rst
-include LICENSE.txt
 include CONTRIBUTING.rst
 include CONTRIBUTORS.txt
+include LICENSE.txt
 include COPYRIGHT.txt
 
-include pyproject.toml setup.cfg
-include .coveragerc
-include tox.ini rtd.txt
-include .readthedocs.yaml
+include .coveragerc pyproject.toml setup.cfg
+include tox.ini .readthedocs.yaml
+graft .github
 
-recursive-exclude * __pycache__ *.py[cod]
+global-exclude __pycache__ *.py[cod]
+global-exclude .DS_Store

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,8 @@ description = A library for deferring decorator actions
 long_description = file: README.rst, CHANGES.rst
 long_description_content_type = text/x-rst
 keywords = web wsgi zope
-license_file = LICENSE.txt
+license_files =
+    LICENSE.txt
 license = BSD-derived (Repoze)
 classifiers =
     Development Status :: 6 - Mature


### PR DESCRIPTION
Suppress warnings where possible (some still emitted by 'build', but they match those from Pyramid).

Discovered while chasing down local tox failures on my machine.