### PR TITLE
Accommodate FrameLocalsProxy introduction in Python 3.13

### DIFF
--- a/tests/test_advice.py
+++ b/tests/test_advice.py
@@ -93,7 +93,9 @@ class FrameInfoTest(unittest.TestCase):
             sys._getframe()
         )
         self.assertEqual(kind, "function call")
-        self.assertTrue(f_locals is locals())  # ???
+        frame = sys._getframe()
+        self.assertEqual(f_locals, frame.f_locals)
+        self.assertEqual(f_locals, locals())
         for d in module.__dict__, f_globals:
             self.assertTrue(d is globals())
         self.assertEqual(len(codeinfo), 4)


### PR DESCRIPTION
The `frame.f_locals` is now a write-through proxy object of type `FrameLocalsProxy`; see PEP 667. This fix is based on https://github.com/zopefoundation/zope.interface/pull/294 and specifically on
https://github.com/zopefoundation/zope.interface/pull/294#issuecomment-2109776671.

Fixes #91.