### PR TITLE
try macos-latest after python github-actions version bump

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -27,7 +27,7 @@ jobs:
                 os:
                     - "ubuntu-latest"
                     - "windows-latest"
-                    - "macos-12" # (later seem to fail building python)
+                    - "macos-latest" # (later seem to fail building python)
                 architecture:
                     - x64
                     - x86
@@ -36,7 +36,7 @@ jobs:
                     # Linux and macOS don't have x86 python
                     - os: "ubuntu-latest"
                       architecture: x86
-                    - os: "macos-12"
+                    - os: "macos-latest"
                       architecture: x86
 
         name: "Python: ${{ matrix.py }}-${{ matrix.architecture }} on ${{ matrix.os }}"


### PR DESCRIPTION
Try macos-latest again after bumping GitHub actions version for Python.