### PR TITLE
Do not swallow callback's ValueError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ exclude = '''
   \.git
   | .tox
   | build
+  | env
 )/
 '''
 
@@ -17,4 +18,5 @@ exclude = '''
 [tool.isort]
 profile = "black"
 src_paths = ["src", "tests"]
+skip_glob = "env/*"
 known_first_party = "venusian"

--- a/src/venusian/__init__.py
+++ b/src/venusian/__init__.py
@@ -175,17 +175,18 @@ class Scanner(object):
                     return
             for category in category_keys:
                 callbacks = attached_categories.get(category, [])
-                try:
-                    # Metaclasses might trick us by reaching this far and then
-                    # fail with too little values to unpack.
-                    for callback, cb_mod_name, liftid, scope in callbacks:
-                        if cb_mod_name != mod_name:
-                            # avoid processing objects that were imported into
-                            # this module but were not actually defined there
-                            continue
-                        callback(self, name, ob)
-                except ValueError:  # pragma: nocover
-                    continue
+                for cb_tuple in callbacks:
+                    try:
+                        # Metaclasses might trick us by reaching this far and then
+                        # fail with too little values to unpack.
+                        callback, cb_mod_name, liftid, scope = cb_tuple
+                    except ValueError:  # pragma: nocover
+                        continue
+                    if cb_mod_name != mod_name:
+                        # avoid processing objects that were imported into
+                        # this module but were not actually defined there
+                        continue
+                    callback(self, name, ob)
 
         for name, ob in getmembers(package):
             # whether it's a module or a package, we need to scan its

--- a/tests/fixtures/callback_valueerror/__init__.py
+++ b/tests/fixtures/callback_valueerror/__init__.py
@@ -1,0 +1,14 @@
+import venusian
+
+
+def decorator(wrapped):
+    def callback(context, name, ob):
+        raise ValueError
+
+    venusian.attach(wrapped, callback)
+    return wrapped
+
+
+@decorator
+def function(request):  # pragma: no cover
+    return request

--- a/tests/test_venusian.py
+++ b/tests/test_venusian.py
@@ -426,6 +426,15 @@ class TestScanner(unittest.TestCase):
         self.assertEqual(test.registrations[0]["ob"], func1)
         self.assertEqual(test.registrations[0]["function"], True)
 
+    def test_valueerror_during_scan_in_callback(self):
+        from tests.fixtures import callback_valueerror
+
+        test = _Test()
+        scanner = self._makeOne(test=test)
+        # without a custom onerror, scan will propagate the importerror from
+        # will_cause_import_error
+        self.assertRaises(ValueError, scanner.scan, callback_valueerror)
+
     def test_ignore_by_full_dotted_name(self):
         from tests.fixtures import one
 


### PR DESCRIPTION
This defers the tuple destructuring in callback execution out of the for-loop and places it in a tighter try/except block to protect against metaclass shenanigans. The `callback(...)` call is therefore moved _outside_ of the try/except block and any `ValueError`s raised here do not get swallowed (resolves #98).

There's also a small fix to the toml file to exclude the `env` directory from black and isort. Following the [contribution setup instructions](https://github.com/Pylons/venusian/blob/main/CONTRIBUTING.rst#get-started) this directory is placed inside the git repo but wasn't yet excluded from lint checks (both slowing linting down and failing for unrelated reasons).