### PR TITLE
Add .mailmap and update my CONTRIBUTORS.txt entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Delta Regeer <xistence@0x58.com> <bertjw@regeer.org>
+Delta Regeer <xistence@0x58.com> <xistence@0x58.com>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -107,7 +107,7 @@ Contributors
 - Olaf Conradi, 2013/09/16
 - Wichert Akkerman, 2015/02/23
 - Marc Abramowitz, 2015/02/24
-- Bert JW Regeer, 2017-04-24
+- Delta Regeer, 2017-04-24
 - Steve Piercy, 2017-08-31
 - Gouji Ochiai, 2022-12-23
 - Florian Schulze, 2023-10-31

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,7 +10,7 @@ include CONTRIBUTORS.txt
 include LICENSE.txt
 include COPYRIGHT.txt
 
-include .coveragerc pyproject.toml setup.cfg
+include .coveragerc .mailmap pyproject.toml setup.cfg
 include tox.ini .readthedocs.yaml
 graft .github
 


### PR DESCRIPTION
Adds a `.mailmap` so my commits resolve to my current name and email. It maps
by commit email, which covers every historical variant. Display-only — the
commit objects themselves are unchanged.

Also updates my `CONTRIBUTORS.txt` entry to match.
`.mailmap` is added to `MANIFEST.in` so check-manifest stays happy.